### PR TITLE
fix(cli): Use correct executable name

### DIFF
--- a/iina-cli/main.swift
+++ b/iina-cli/main.swift
@@ -19,7 +19,7 @@ execURL.resolveSymlinksInPath()
 
 let processInfo = ProcessInfo.processInfo
 
-let iinaPath = execURL.deletingLastPathComponent().appendingPathComponent("IINA").path
+let iinaPath = execURL.deletingLastPathComponent().appendingPathComponent("IINA Advance").path
 
 guard FileManager.default.fileExists(atPath: iinaPath) else {
   print("Cannot find IINA binary. This command line tool only works in IINA.app bundle.")


### PR DESCRIPTION
Simple fix to have `iina-cli` correctly reference the "IINA Advance" executable. 

Users can now do the normal
`ln -s /Applications/IINA\ Advance.app/Contents/MacOS/iina-cli iina`
and launch `iina` from the command line.

Aside:
Doing `iina video.mp4` works as expected, but it doesn't seem to be processing the mpv arguments like base iina does. eg `iina video.mp4 -- --loop-file=inf` works with base iina and not here. Not a big deal to me but I'm just noting.
