### PR TITLE
Fix keyboard config import

### DIFF
--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -216,7 +216,7 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
     Utility.quickOpenPanel(title: "Select Conf File to Import", chooseDir: false, sheetWindow: view.window,
                            allowedFileTypes: [Constants.InputConf.fileExtension]) { url in
       guard url.isFileURL, url.lastPathComponent.hasSuffix(Constants.InputConf.fileExtension) else { return }
-      self.confTableController?.importConfFiles([url.lastPathComponent])
+      self.confTableController?.importConfFiles([url.path])
     }
   }
 


### PR DESCRIPTION
- [ ] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #. 🤷‍♂️ 

---

**Description:**

When I try to import a keyboard config:

<img width="214" height="357" alt="A screenshot with preferences UI showing different keyboard shortcut config profiles and a red arrow pointing at the “Import existing config file” button" src="https://github.com/user-attachments/assets/3a4630f7-e34c-4312-8fa6-2b377c0cca3f" />

Two(!) pop-ups like this would be shown:

<img width="256" height="245" alt="A screenshot of a pop-up alert saying “Error parsing keybinding configuration file”, etc." src="https://github.com/user-attachments/assets/753c58da-1b12-4209-aa32-f77a8ee5413e" />
