### PR TITLE
fix: subtitle search mpv-queue assert + subtitle chooser zero-height table

### DIFF
--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -147,7 +147,14 @@ class OpenSub {
         }.then {
           self.hash(url)
         }.then { hash in
-          self.searchForSubtitles(url, hash, player.getMediaTitle())
+          // getMediaTitle must run on the mpv queue
+          Promise<String> { resolver in
+            player.mpv.queue.async {
+              resolver.fulfill(player.getMediaTitle())
+            }
+          }.then { mediaTitle in
+            self.searchForSubtitles(url, hash, mediaTitle)
+          }
         }.then { subs in
           self.showSubSelectWindow(with: subs)
         }

--- a/iina/SubChooseViewController.swift
+++ b/iina/SubChooseViewController.swift
@@ -33,7 +33,17 @@ class SubChooseViewController: NSViewController {
       } else {
         scrollView.layer?.cornerRadius = 6
       }
+
+      // The scroll view has no intrinsic height. Its only height source in the XIB is a
+      // priority-99 (>= 200) constraint on the root view, which loses to the OSD stack view's
+      // vertical hugging (500), collapsing the table to zero height. Pin a minimum height with
+      // a priority high enough to win against the stack view, but below the window's required
+      // layout constraints.
+      let minHeightConstraint = scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 156)
+      minHeightConstraint.priority = .init(600)
+      minHeightConstraint.isActive = true
     }
+    view.setContentCompressionResistancePriority(.init(600), for: .vertical)
 
     tableView.delegate = self
     tableView.dataSource = self


### PR DESCRIPTION
Two small, independent bug fixes in the built-in Open Subtitles flow. Both are corrections to existing behavior (no enhancements to the downloader), Swift/XIB-constraint only.

## 1. Crash: subtitle search calls `getMediaTitle()` off the mpv queue

`OpenSub.Fetcher.fetch` calls `player.getMediaTitle()` from a PromiseKit continuation running on the main queue, but `PlayerCore.getMediaTitle()` begins with `assert(DispatchQueue.isExecutingIn(mpv.queue))`. On Debug builds this trips an assertion failure (`EXC_BREAKPOINT`) the moment results come back from a subtitle search; Release builds compile the assert out but still read the `media-title` property from the wrong thread.

Fix: hop to the mpv queue to read the title before searching.

- Before: `iina/OpenSubSubtitle.swift` — `self.searchForSubtitles(url, hash, player.getMediaTitle())`
- After: the title is fetched inside `player.mpv.queue.async` and then passed to `searchForSubtitles`.

## 2. Layout: subtitle chooser table collapses to zero height

When the "N subtitles found" chooser is shown as an OSD accessory, its scroll view has no intrinsic height and its only height source in `SubChooseViewController.xib` is a priority-99 (`>= 200`) constraint on the root view, which loses to the OSD stack view's vertical hugging (500). The table collapses to zero height, leaving no rows to select and the **Download** button permanently disabled (only the title/caption and Cancel/Download buttons remain visible).

Fix: pin a minimum scroll-view height at a priority high enough to win against the stack view but below the window's required constraints.

## Testing

Built and run from a fork that contains these two commits (plus unrelated local changes); the chooser now shows its rows and the search no longer asserts. The two commits are independent and can be taken separately.
